### PR TITLE
Update ActionSubscriber to reduce  Fluxor.DisposableCallbacks

### DIFF
--- a/Source/Lib/Fluxor/ActionSubscriber.cs
+++ b/Source/Lib/Fluxor/ActionSubscriber.cs
@@ -77,6 +77,11 @@ namespace Fluxor
 				if (!SubscriptionsForInstance.TryGetValue(subscriber, out instanceSubscriptions))
 					return;
 
+				IEnumerable<object> subscribedInstances =
+				    instanceSubscriptions
+					.Select(x => x.Subscriber)
+					.Distinct();
+					
 				IEnumerable<Type> subscribedActionTypes =
 					instanceSubscriptions
 						.Select(x => x.ActionType)
@@ -90,6 +95,12 @@ namespace Fluxor
 					SubscriptionsForType[actionType] = actionTypeSubscriptions
 						.Except(instanceSubscriptions)
 						.ToList();
+				}
+				
+				foreach (object subscription in subscribedInstances)
+				{
+				    if (SubscriptionsForInstance.ContainsKey(subscription))
+					SubscriptionsForInstance.Remove(subscription);
 				}
 			}
 		}


### PR DESCRIPTION
We have a production version of Blazor Server running on Azure, that extensively uses Fluxor. We were investigating a memory leak and have found that the application is holding on to Flxuor Subscriptions preventing the subscription from being removed through the GC.
Memory analysis report shows 15K Fluxor.DisposableCallbacks in the "Finalizable objects require multiple garbage collection to clean up and may cause performance issues" after 15 hours of up time and a maximum of 40 users.
With this change it drops to around 700.
This wasn't the cause our memory leak. Our memory leak prevented the whole session from being disposed. This meant before the memory leak was resolved, we had 250K instances of Fluxor.DisposableCallbacks which is what led us to investigate in the first place